### PR TITLE
Correct typo error, from dose to does on line 177

### DIFF
--- a/en/source/spanning_tree.rst
+++ b/en/source/spanning_tree.rst
@@ -174,7 +174,7 @@ Source name: ``simple_switch_stp_13.py``
 
 .. NOTE::
 
-    If using the Open vSwitch, this application dose not wrok well depending
+    If using the Open vSwitch, this application does not wrok well depending
     on the Open vSwitch's settings or version.
     Open vSwitch has the STP implementation, but if this option is disabled
     (by default), Open vSwitch drops the STP (BPDU) packets with the dest mac


### PR DESCRIPTION
Correcting typo: from "dose not" to "does not" on line 177